### PR TITLE
Relax the chef version constraint to allow v11

### DIFF
--- a/knife-dsl.gemspec
+++ b/knife-dsl.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'chef', '~> 10.0'
+  gem.add_dependency 'chef', '>= 10.0'
 end


### PR DESCRIPTION
I wanted to use chef-workflow to trial Chef 11 but this pesky twiddle wakka was keeping me back (at least when using Bundler). Did not have any adverse affects at least during my tests.
